### PR TITLE
Bugfix: dont find youtube ID in mobile

### DIFF
--- a/youtube-parser/Youtube.swift
+++ b/youtube-parser/Youtube.swift
@@ -15,7 +15,16 @@ public extension NSURL {
   @return key value dictionary with each parameter as an array
   */
   func dictionaryForQueryString() -> [String: AnyObject]? {
-    return self.query?.dictionaryFromQueryStringComponents()
+    if let query = self.query {
+      return query.dictionaryFromQueryStringComponents()
+    }
+
+    // Note: find youtube ID in m.youtube.com "https://m.youtube.com/#/watch?v=1hZ98an9wjo"
+    let result = absoluteString.componentsSeparatedByString("?")
+    if result.count > 1 {
+      return result.last?.dictionaryFromQueryStringComponents()
+    }
+    return nil
   }
 }
 

--- a/youtube-parserTests/youtube_parserTests.swift
+++ b/youtube-parserTests/youtube_parserTests.swift
@@ -47,6 +47,14 @@ class youtube_parserTests: XCTestCase {
     }
   }
 
+  func testYoutubeIDFromMobileYoutubeURL() {
+    let sampleLink = NSURL(string: "https://m.youtube.com/#/watch?v=1hZ98an9wjo")!
+    XCTAssertNotNil(Youtube.youtubeIDFromYoutubeURL(sampleLink), "Youtube ID is nil")
+    if let youtubeID = Youtube.youtubeIDFromYoutubeURL(sampleLink) {
+      XCTAssertEqual(youtubeID, "1hZ98an9wjo", "Youtube ID not same")
+    }
+  }
+
   func testH264videosWithYoutubeURL() {
     if let videoComponents = Youtube.h264videosWithYoutubeID("1hZ98an9wjo") {
       XCTAssertNotNil(videoComponents, "video component is nil")


### PR DESCRIPTION
I dont find youtube ID in iOS's UIWebView when using this library.

I investigated and found the issue that `https://m.youtube.com/#/watch?` is unsupported by NSURL
